### PR TITLE
docker build fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/ubuntu
+FROM ubuntu
 
 # Install MongoDB.
 RUN \


### PR DESCRIPTION
reason: wrong parent image.
fix: update parent image ref.